### PR TITLE
Usability pass

### DIFF
--- a/lib/pmlcode.rb
+++ b/lib/pmlcode.rb
@@ -10,4 +10,5 @@ module PMLCode
   autoload :Updater, 'pmlcode/updater'
   autoload :Content, 'pmlcode/content'
   autoload :Display, 'pmlcode/display'
+  autoload :Source,  'pmlcode/source'
 end

--- a/lib/pmlcode.rb
+++ b/lib/pmlcode.rb
@@ -1,4 +1,6 @@
 require "nokogiri"
+require "rainbow"
+
 require "fileutils"
 
 require "pmlcode/version"
@@ -6,4 +8,5 @@ require "pmlcode/version"
 module PMLCode
   autoload :CLI,     'pmlcode/cli'
   autoload :Updater, 'pmlcode/updater'
+  autoload :Content, 'pmlcode/content'
 end

--- a/lib/pmlcode.rb
+++ b/lib/pmlcode.rb
@@ -9,4 +9,5 @@ module PMLCode
   autoload :CLI,     'pmlcode/cli'
   autoload :Updater, 'pmlcode/updater'
   autoload :Content, 'pmlcode/content'
+  autoload :Display, 'pmlcode/display'
 end

--- a/lib/pmlcode/cli.rb
+++ b/lib/pmlcode/cli.rb
@@ -8,6 +8,8 @@ module PMLCode::CLI
 
       pmlcode [PML_PATH, ...] [OPTIONS]
 
+  PML_PATHs can optionally include a :LINENUM suffix.
+
   ## SYNOPSIS
 
   Looks for `<embed>` tags whose `file` attribute match `--pattern`, extracting the
@@ -80,11 +82,11 @@ module PMLCode::CLI
     parser = build_parser(options)
     parser.parse!(args)
 
-    files = prepare(options, parser, args)
+    sources = prepare(options, parser, args)
 
-    files.each do |pml|
-      options.pml = pml
-      options.output = File.dirname(pml)
+    sources.each do |source|
+      options.source = source
+      options.output = File.dirname(source.path)
       update!(options)
     end
 
@@ -119,14 +121,14 @@ module PMLCode::CLI
       $stderr.puts parser
       exit
     end
-    files = args.map { |pml| File.expand_path(pml) }
-    missing = files.select { |pml| !File.exists?(pml) }
+    sources = args.map { |pml| PMLCode::Source.parse(pml) }
+    missing = sources.select(&:missing?)
     unless missing.empty?
-      $stderr.puts "PML files #{missing} not found"
+      $stderr.puts "PML sources #{missing} not found"
       puts parser
       exit
     end
-    files
+    sources
   end
 
   def self.build_parser(options)
@@ -151,6 +153,10 @@ module PMLCode::CLI
 
       opts.on("-V", "--verbose", "Verbose output (Only useful with --content)") do
         options.verbose = true
+      end
+
+      opts.on('-x', '--dry-run', "Dry run (do not write files)") do
+        options.dry_run = true
       end
 
       opts.on_tail("-h", "--help", "Show this message") do

--- a/lib/pmlcode/cli.rb
+++ b/lib/pmlcode/cli.rb
@@ -145,6 +145,14 @@ module PMLCode::CLI
         options.pattern = Regexp.new(value)
       end
 
+      opts.on('-c', '--content', "Show content") do
+        options.content = true
+      end
+
+      opts.on("-V", "--verbose", "Verbose output (Only useful with --content)") do
+        options.verbose = true
+      end
+
       opts.on_tail("-h", "--help", "Show this message") do
         puts opts
         exit

--- a/lib/pmlcode/content.rb
+++ b/lib/pmlcode/content.rb
@@ -1,4 +1,5 @@
 class PMLCode::Content
+  include Enumerable
 
   def self.parse(text)
     parser = Parser.new(text)
@@ -11,6 +12,10 @@ class PMLCode::Content
 
   def has_part?(name)
     @lines.any? { |l| l.part == name }
+  end
+
+  def each(&block)
+    @lines.each(&block)
   end
 
   def to_s

--- a/lib/pmlcode/content.rb
+++ b/lib/pmlcode/content.rb
@@ -1,0 +1,85 @@
+class PMLCode::Content
+
+  def self.parse(text)
+    parser = Parser.new(text)
+    new(parser.result)
+  end
+
+  def initialize(lines)
+    @lines = lines
+  end
+
+  def has_part?(name)
+    @lines.any? { |l| l.part == name }
+  end
+
+  def to_s
+    @lines.map(&:text)
+  end
+
+  class Line
+
+    attr_reader :text, :part
+
+    def initialize(text, part, highlighted = false)
+      @text = text
+      @part = part
+      @highlighted = highlighted
+    end
+
+    def highlighted?
+      @highlighted
+    end
+
+  end
+
+  class Parser
+
+    PART_START = /START:\s?(\S+)/
+    PART_END = /END:\s?(\S+)/
+
+    HL_START = /START_HIGHLIGHT/
+    HL_END = /END_HIGHLIGHT/
+
+    def initialize(raw)
+      @raw = raw
+    end
+
+    def result
+      @result ||= run
+    end
+
+    private
+
+    def run
+      @part = nil
+      @highlighted = nil
+      lines.map(&method(:process)).compact
+    end
+
+    def process(text)
+      case text
+      when PART_START
+        @part = $1
+        nil
+      when PART_END
+        @part = nil
+        nil
+      when HL_START
+        @highlighted = true
+        nil
+      when HL_END
+        @highlighted = false
+        nil
+      else
+        Line.new(text, @part, @highlighted)
+      end
+    end
+
+    def lines
+      @raw.split(/\r?\n/)
+    end
+
+  end
+
+end

--- a/lib/pmlcode/display.rb
+++ b/lib/pmlcode/display.rb
@@ -2,7 +2,7 @@ class PMLCode::Display
 
   INDENT = " " * 4
 
-  def initialize(content, part, options = {})
+  def initialize(content, part, options)
     @content = content
     @part = part
     @options = options
@@ -17,12 +17,14 @@ class PMLCode::Display
   private
 
   def format_line(line)
-    if @part && line.part != @part && @options[:expanded]
+    if @part && !line.in_part?(@part) && @options.verbose
       Rainbow(line.text).black
-    elsif line.highlighted?
-      Rainbow(line.text).yellow.bold
-    else
-      line.text
+    elsif !@part || (@part && line.in_part?(@part))
+      if line.highlighted?
+        Rainbow(line.text).yellow.bold
+      else
+        line.text
+      end
     end
   end
 

--- a/lib/pmlcode/display.rb
+++ b/lib/pmlcode/display.rb
@@ -1,0 +1,29 @@
+class PMLCode::Display
+
+  INDENT = " " * 4
+
+  def initialize(content, part, options = {})
+    @content = content
+    @part = part
+    @options = options
+  end
+
+  def to_s
+    INDENT + "```\n" + \
+    @content.map(&method(:format_line)).compact.map { |l| INDENT + l }.join("\n") + "\n" + \
+    INDENT + "```"
+  end
+
+  private
+
+  def format_line(line)
+    if @part && line.part != @part && @options[:expanded]
+      Rainbow(line.text).black
+    elsif line.highlighted?
+      Rainbow(line.text).yellow.bold
+    else
+      line.text
+    end
+  end
+
+end

--- a/lib/pmlcode/source.rb
+++ b/lib/pmlcode/source.rb
@@ -1,0 +1,25 @@
+class PMLCode::Source
+
+  PATTERN = /^(?<path>.+?)(:(?<line>\d+):?)?$/
+
+  def self.parse(text)
+    if (match = text.match(PATTERN))
+      new(match[:path], match[:line] ? Integer(match[:line]) : nil)
+    end
+  end
+
+  attr_reader :path, :line
+  def initialize(path, line)
+    @path = File.expand_path(path)
+    @line = line
+  end
+
+  def missing?
+    !File.exists?(@path)
+  end
+
+  def to_s
+    [@path, @line].join(":")
+  end
+
+end

--- a/lib/pmlcode/updater.rb
+++ b/lib/pmlcode/updater.rb
@@ -87,8 +87,8 @@ class PMLCode::Updater
   end
 
   def check_part!(text, part)
+    content = PMLCode::Content.parse(text)
     if part
-      content = PMLCode::Content.parse(text)
       if content.has_part?(part)
         print Rainbow("OK").green
       else
@@ -98,6 +98,8 @@ class PMLCode::Updater
       print Rainbow("--").gray
     end
     puts " : PART #{part}"
+    puts "\n"
+    puts PMLCode::Display.new(content, part)
   end
 
   def generate_content_id(match)

--- a/lib/pmlcode/updater.rb
+++ b/lib/pmlcode/updater.rb
@@ -99,7 +99,9 @@ class PMLCode::Updater
     end
     puts " : PART #{part}"
     puts "\n"
-    puts PMLCode::Display.new(content, part)
+    if @options.content
+      puts PMLCode::Display.new(content, part, @options)
+    end
   end
 
   def generate_content_id(match)

--- a/lib/pmlcode/updater.rb
+++ b/lib/pmlcode/updater.rb
@@ -42,7 +42,7 @@ class PMLCode::Updater
   end
 
   def initialize(options)
-    @pml = options.pml
+    @source = options.source
     @options = options
     @current_prefix = nil
     @wrote = {}
@@ -51,20 +51,26 @@ class PMLCode::Updater
 
   def embeds
     @embeds ||= begin
-      doc = Nokogiri::XML(File.read(@pml))
-      doc.css('embed')
+      doc = Nokogiri::XML(File.read(@source.path))
+      doc.css('embed').select do |embed|
+        if @source.line
+          embed.line == @source.line
+        else
+          true
+        end
+      end
     end
   end
 
   def run
     embeds.each do |embed|
-      puts Rainbow(File.basename(@pml) + ":#{embed.line} ").bold.underline
+      puts Rainbow(File.basename(@source.path) + ":#{embed.line} ").bold.underline
       match = @options.pattern.match(embed[:file])
       if match
         text = dedup(match) { |already_wrote| update(match, already_wrote) }
         if text
           print Rainbow("OK").green
-          puts " : FILE #{embed[:file]}"
+          puts " : FILE #{embed[:file]} #{write_flag}"
           check_part!(text, embed[:part])
         else
           print Rainbow("ERROR").red
@@ -101,6 +107,14 @@ class PMLCode::Updater
     puts "\n"
     if @options.content
       puts PMLCode::Display.new(content, part, @options)
+    end
+  end
+
+  def write_flag
+    if @options.dry_run
+      Rainbow("  DRY RUN  ").green.inverse
+    else
+      Rainbow("  WRITTEN  ").yellow.inverse
     end
   end
 

--- a/lib/pmlcode/updaters/full_updater.rb
+++ b/lib/pmlcode/updaters/full_updater.rb
@@ -10,11 +10,12 @@ class PMLCode::FullUpdater < PMLCode::Updater
     full_path = directory(match)
     FileUtils.mkdir_p(full_path)
     success = false
+    content = nil
     Dir.chdir(@options.app) do
+      content = `git show origin/#{match[:chapter]}.#{match[:snapshot]}:#{match[:path]}`
       system "git archive '#{match[:chapter]}.#{match[:snapshot]}' | tar -x -C '#{full_path}'"
-      success = $?.success?
     end
-    success
+    success ? content : nil
   end
 
   def generate_update_id(match)

--- a/lib/pmlcode/updaters/full_updater.rb
+++ b/lib/pmlcode/updaters/full_updater.rb
@@ -13,7 +13,7 @@ class PMLCode::FullUpdater < PMLCode::Updater
     content = nil
     Dir.chdir(@options.app) do
       content = `git show origin/#{match[:chapter]}.#{match[:snapshot]}:#{match[:path]}`
-      if already_wrote
+      if already_wrote || @options.dry_run
         success = true
       else
         system "git archive '#{match[:chapter]}.#{match[:snapshot]}' | tar -x -C '#{full_path}'"

--- a/lib/pmlcode/updaters/full_updater.rb
+++ b/lib/pmlcode/updaters/full_updater.rb
@@ -6,14 +6,19 @@ class PMLCode::FullUpdater < PMLCode::Updater
 
   private
 
-  def update(match)
+  def update(match, already_wrote)
     full_path = directory(match)
     FileUtils.mkdir_p(full_path)
     success = false
     content = nil
     Dir.chdir(@options.app) do
       content = `git show origin/#{match[:chapter]}.#{match[:snapshot]}:#{match[:path]}`
-      system "git archive '#{match[:chapter]}.#{match[:snapshot]}' | tar -x -C '#{full_path}'"
+      if already_wrote
+        success = true
+      else
+        system "git archive '#{match[:chapter]}.#{match[:snapshot]}' | tar -x -C '#{full_path}'"
+        success = $?
+      end
     end
     success ? content : nil
   end

--- a/lib/pmlcode/updaters/sparse_updater.rb
+++ b/lib/pmlcode/updaters/sparse_updater.rb
@@ -6,7 +6,7 @@ class PMLCode::SparseUpdater < PMLCode::Updater
 
   private
 
-  def update(match)
+  def update(match, already_wrote)
     success = false
     content = nil
     Dir.chdir(@options.app) do
@@ -14,10 +14,12 @@ class PMLCode::SparseUpdater < PMLCode::Updater
       success = $?.success?
     end
     if success
-      full_path = File.join(directory(match), match[:path])
-      FileUtils.mkdir_p(File.dirname(full_path))
-      File.open(full_path, 'w') do |f|
-        f.write(content)
+      unless already_wrote
+        full_path = File.join(directory(match), match[:path])
+        FileUtils.mkdir_p(File.dirname(full_path))
+        File.open(full_path, 'w') do |f|
+          f.write(content)
+        end
       end
       content
     end

--- a/lib/pmlcode/updaters/sparse_updater.rb
+++ b/lib/pmlcode/updaters/sparse_updater.rb
@@ -19,7 +19,7 @@ class PMLCode::SparseUpdater < PMLCode::Updater
       File.open(full_path, 'w') do |f|
         f.write(content)
       end
-      true
+      content
     end
   end
 

--- a/lib/pmlcode/updaters/sparse_updater.rb
+++ b/lib/pmlcode/updaters/sparse_updater.rb
@@ -14,7 +14,7 @@ class PMLCode::SparseUpdater < PMLCode::Updater
       success = $?.success?
     end
     if success
-      unless already_wrote
+      unless already_wrote || @options.dry_run
         full_path = File.join(directory(match), match[:path])
         FileUtils.mkdir_p(File.dirname(full_path))
         File.open(full_path, 'w') do |f|

--- a/pmlcode.gemspec
+++ b/pmlcode.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'nokogiri', '~> 1.8', '>= 1.8.0'
+  spec.add_runtime_dependency 'rainbow', '~> 2.2'
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Adds a raft of features:

- Warns when a part isn't present (Resolves #1)
- Colorized display
- Display embedded part of file (`--content`)
- Display whole file, with unused part darkened (`--verbose` when `--content`)
- Display highlights (with `--content`)
- `--dry-run` that doesn't write files
- Support `PML_PATH:LINENUM` inputs for specific embeds